### PR TITLE
Normalize and expand user in virutal sd path

### DIFF
--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -57,6 +57,7 @@ class web_dwc2:
 		#	grab stuff from config file
 		self.klipper_config = self.printer.get_start_args()['config_file']
 		self.sdpath = self.configfile.getsection("virtual_sdcard").get("path", None)
+		self.sdpath = os.path.normpath(os.path.expanduser(self.sdpath))
 		if not self.sdpath:
 			logging.error( "DWC2 failed to start, no sdcard configured" )
 			return


### PR DESCRIPTION
Normalizes the path in exactly the same way as it's done in the virtual_sdcard module in klipper.
Using paths such as ~/virt_sd/ previously caused errors.

This patch allows people to use paths relative to their home folder as their virtual sdcard without any problems.