### PR TITLE
Fix regex that filter temp status messages

### DIFF
--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -459,7 +459,7 @@ class web_dwc2:
 					"type": "f" ,
 					"name": macro_ ,
 					"size": 1 ,
-					"date": time.strftime("%Y-%m-%dT%H:%M:%S") 
+					"date": time.strftime("%Y-%m-%dT%H:%M:%S")
 				})
 
 		#	virtual config file
@@ -871,7 +871,7 @@ class web_dwc2:
 
 		if self.chamber:
 			chamber_stats = self.chamber.get_status(0)
-			self.status_2['temps'].update({ 
+			self.status_2['temps'].update({
 				"chamber": {
 					"current": chamber_stats.get("temp") ,
 					"active": chamber_stats.get("target", -1) ,
@@ -1098,7 +1098,7 @@ class web_dwc2:
 		self.sdcard.must_pause_work = True 		#	pause print -> sdcard postion is saved in virtual sdcard
 		self.sdcard.file_position = 0			#	reset fileposition
 		self.sdcard.work_timer = None 			#	reset worktimer
-		self.sdcard.current_file = None 		#	
+		self.sdcard.current_file = None 		#
 		self.printfile = None
 		self.cancel_macro()
 		#	let user define a cancel/pause print macro`?
@@ -1216,9 +1216,9 @@ class web_dwc2:
 			self.reactor.register_callback(self.gcode_reactor_callback)
 	#	getting response by callback
 	def gcode_response(self, msg):
-		
+
 		if self.klipper_ready:
-			if re.match('T\d:\d+.\d\s/\d+.\d+', msg): return	#	filters tempmessages during heatup
+			if re.match('[BT]\d?:\d+.\d+\s/\d+.\d+', msg): return	#	filters tempmessages during heatup
 
 		self.gcode_reply.append(msg)
 	#	recall for gcode ecxecution is needed ( threadsafeness )
@@ -1486,7 +1486,7 @@ class web_dwc2:
 			]
 
 			#	heigth of the first layer
-		first_h = [ 
+		first_h = [
 			'first_layer_thickness_mm\s=\s\d+\.\d+' , 		#	kisslicers setting
 			'; first_layer_height =' ,						# 	Slic3r
 			'\sZ\\d+.\\d*' ,								#	Simplify3d
@@ -1523,7 +1523,7 @@ class web_dwc2:
 			';Material#1 Used:\s\d+\.?\d+'					#	ideamaker
 			]
 		#	slicernames
-		slicers = [ 
+		slicers = [
 			'KISSlicer' ,
 			'^Slic3r$' ,
 			'Simplify3D\(R\).*' ,
@@ -1542,9 +1542,9 @@ class web_dwc2:
 			s_str = re.search(re.compile('(\d+(\s)?seconds|\d+(\s)?s)'),in_)
 			dursecs = 0
 			if h_str:
-				dursecs += float( max( re.findall('([0-9]*\.?[0-9]+)' , ''.join(h_str.group()) ) ) ) *3600 
+				dursecs += float( max( re.findall('([0-9]*\.?[0-9]+)' , ''.join(h_str.group()) ) ) ) *3600
 			if m_str:
-				dursecs += float( max( re.findall('([0-9]*\.?[0-9]+)' , ''.join(m_str.group()) ) ) ) *60 
+				dursecs += float( max( re.findall('([0-9]*\.?[0-9]+)' , ''.join(m_str.group()) ) ) ) *60
 			if s_str:
 				dursecs += float( max( re.findall('([0-9]*\.?[0-9]+)' , ''.join(s_str.group()) ) ) )
 			if dursecs == 0:
@@ -1575,7 +1575,7 @@ class web_dwc2:
 					matches = re.findall(objects_h[sl], pile )
 					meta['objects_h'] = max( [ float(mat_) for mat_ in re.findall("\d*\.\d*", ' '.join(matches) ) ] )
 				except:
-					pass				
+					pass
 			if layer_h[sl] != "":
 				try:
 					matches = re.findall(layer_h[sl], pile )
@@ -1601,7 +1601,7 @@ class web_dwc2:
 					meta['filament'] = (meta['filament'],meta['filament']*1000)[sl==4]	#	cura is in m -> translate
 				except:
 					pass
-			
+
 		else:
 			self.gcode_reply.append("Your Slicer is not yet implemented.")
 


### PR DESCRIPTION
This fix does correctly filter out temperature status messages that in my case were as follows:
B:24.2 /0.0 T0:122.7 /205.0

Another alternative for the regex would be:
re.match('[BT]\d?:\d+.\d+\s/\d+.\d+', msg)