### PR TITLE
Shut Up PollConnector!

### DIFF
--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -228,8 +228,8 @@ class web_dwc2:
 				return
 			#	filehandling - dircreation
 			elif "rr_mkdir" in self.request.uri:
-				self.web_dwc2.rr_mkdir(self)
-				return
+				self.repl_ = self.web_dwc2.rr_mkdir(self)
+				#return
 			elif "rr_move" in self.request.uri:
 				self.repl_ = self.web_dwc2.rr_move(self)
 			#	gcode reply
@@ -583,10 +583,13 @@ class web_dwc2:
 		path_ = self.sdpath + web_.get_argument('dir').replace("0:", "").replace(' ', '_')
 
 		if not os.path.exists(path_):
-			os.makedirs(path_)
+			try:
+				os.makedirs(path_)
+			except Exception as e:
+				return {'err': e}
 			return {'err': 0}
 
-		return {'err': 1}
+		return {'err': "Path already exists"}
 	#	dwc rr_reply - fetces gcodes
 	def rr_reply(self, web_):
 		while self.gcode_reply:


### PR DESCRIPTION
Ok, this is a bigger one. I've been just trying to clean up error messages more than anything, and this seems to have done it. The majority for the warnings come through when the printer is off and klipper is waiting to connect. All status requests are forwarded to type 0 instead of the types that have these values in the response, which makes the connector very unhappy because it was expecting a different response. Both status 2 and 3 were expected to report a standby temp for the bed heater, which I thought was odd, but not a big deal I guess. Small usability change: I moved all of the klipper macros to their own folder, and only render them when you are in that folder. Since those files don't actually exist, this keeps them separate from actual dwc macros. I have klipper macros set up for changing tools in klippers config file, and now I can have dwc macros for things that the firmware doesn't need to worry about when printing for example like turning lights on/off.

Non of these changes are strictly "necessary" but they do quite down the warnings. I've been testing, and so far nothing has broken as a result.

Are you happy now PollConnector? Hmm? Now that I have given you all of the variables you could ever possibly want? Are there any other "undefined" values you want fake placeholders for? HMMMM? NO? GOOD!

also put klipper macros in their own folder.