### PR TITLE
Add support for Slic3r++

### DIFF
--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1450,7 +1450,7 @@ class web_dwc2:
 			#	heigth of the first layer
 		first_h = [ 
 			'first_layer_thickness_mm\s=\s\d+\.\d+' , 		#	kisslicers setting
-			'; first_layer_height =' ,						# 	Slic3r
+			'; first_layer_height =' ,						# 	Slic3r || Slic3r++
 			'\sZ\\d+.\\d*' ,								#	Simplify3d
 			'G1\sZ\d*\.\d*' ,								#	Slic3r PE
 			'\sZ\\d+.\\d\s' ,								#	Cura
@@ -1466,7 +1466,7 @@ class web_dwc2:
 			'; layer_height = \d.\d+' ,						#	Slic3r PE
 			';Layer height: \d.\d+' ,						# 	Cura
 			';Z:\d+.\d{3}',									#	ideamaker
-			'; layer_height = \d.\d+'						#	PrusaSlicer
+			'; layer_height = \d.\d+'						#	PrusaSlicer || Slic3r++
 			]
 		#	slicers estimate print time
 		time_e = [
@@ -1476,7 +1476,7 @@ class web_dwc2:
 			'\d+h?\s?\d+m\s\d+s' ,							#	Slic3r PE
 			';TIME:\\d+' ,									#	Cura
 			';Print Time:\s\d+\.?\d+',						#	ideamaker
-			'\d+h?\s?\d+m\s\d+s'							#	PrusaSlicer
+			'\d+h?\s?\d+m\s\d+s'							#	PrusaSlicer || Slic3r++
 			]
 		#	slicers filament usage
 		filament = [
@@ -1486,17 +1486,18 @@ class web_dwc2:
 			'.*filament\sused\s=\s.*mm' ,					#	Slic3r PE ; filament used =
 			';Filament used: \d*.\d+m'	,					#	Cura
 			';Material#1 Used:\s\d+\.?\d+',					#	ideamaker
-			'.*filament\sused\s.mm.\s=\s[0-9\.]+'					#	PrusaSlicer
+			'.*filament\sused\s.mm.\s=\s[0-9\.]+'			#	PrusaSlicer || Slic3r++
 			]
 		#	slicernames
 		slicers = [ 
 			'KISSlicer' ,
-			'^Slic3r$' ,
+			'^Slic3r$',
 			'Simplify3D\(R\).*' ,
 			'Slic3r Prusa Edition\s.*\so',
 			'Cura_SteamEngine.*' ,
 			'ideaMaker\s([0-9]*\..*,)',
-			'PrusaSlicer'
+			'PrusaSlicer',
+			'Slic3r\+\+'
 			]
 		#
 		meta = { "slicer": "Slicer is not implemented" }

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1444,7 +1444,7 @@ class web_dwc2:
 			'G1\sZ\d*\.\d*' ,					# 	Slic3r PE
 			'\sZ\\d+.\\d*' ,					# 	Cura
 			'\sZ\d+.\d{3}' ,					#	ideamaker
-			'G1\sZ\d*\.\d*'  					#	PrusaSlicer
+			'G1\sZ\d*\.\d*'  					#	PrusaSlicer || Slic3r++
 			]
 
 			#	heigth of the first layer


### PR DESCRIPTION
This add supports for Slic3r++ by Supermerill
just a strangeness (it's the same for all slicers): the object max height shown will report the Z max height not the object height. In example, if you have a end gcode that raise Z axis after the print to Z max (in example 250mm) , the object max height is reported as 250mm this because you are looking for the higher number found in G1 Z gcode command.