### PR TITLE
Compensate for klipper refactor

### DIFF
--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -46,7 +46,7 @@ class web_dwc2:
 		self.reactor = self.printer.get_reactor()
 		self.gcode = self.printer.lookup_object('gcode')
 		self.configfile = self.printer.lookup_object('configfile').read_main_config()
-		self.stepper_enable = self.printer.try_load_module(config, "stepper_enable")
+		self.stepper_enable = self.printer.load_object(config, "stepper_enable")
 		#	gcode execution needs
 		self.gcode_queue = []	#	containing gcode user pushes from dwc2
 		self.gcode_reply = []	#	contains the klippy replys


### PR DESCRIPTION
First, thank you for this software!

Second, klipper renamed `try_load_module` in commit
787ed452c2abe3bad81ffaf732b0b2609e3534bb

So this PR will do the same.

This should fix #73, but I'm having problems getting dwc to work with an updated klipper, as after fixing this error, I get a very frequent error of `dict object has no get_command` or somesuch.