### PR TITLE
Klipper gcode.py refactor fixes

### DIFF
--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1228,7 +1228,7 @@ class web_dwc2:
 				self.gcode_queue.append(self.parse_params(line))
 
 		elif 'PAUSE_PRINT' in self.klipper_macros:
-			self.gcode_queue.append(parse_params('PAUSE_PRINT'))
+			self.gcode_queue.append(self.parse_params('PAUSE_PRINT'))
 
 		if self.gcode_queue:
 			self.reactor.register_callback(self.gcode_reactor_callback)

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1085,7 +1085,7 @@ class web_dwc2:
 			#	now we know its no macro file
 			klipma = original.split("/")[-1].replace("\"", "")
 			if klipma in self.klipper_macros:
-				return self.parse_params(klipma)
+				return self.gcode_queue.append(self.parse_params(klipma))
 			else:
 				return None
 		else:
@@ -1112,12 +1112,14 @@ class web_dwc2:
 		self.printer.invoke_shutdown('Emergency Stop from DWC 2')
 	#	save states butttons
 	def cmd_M120(self, gcmd):
-		gcmd._params = {'NAME': 'DWC_BOTTON'}
-		self.gcode.cmd_SAVE_GCODE_STATE(gcmd)
+		gcmd = self.parse_params('SAVE_GCODE_STATE NAME=DWC')
+		handler = self.gcode.gcode_handlers.get("SAVE_GCODE_STATE", self.gcode.cmd_default)
+		handler(gcmd)
 	#	restore states butttons
 	def cmd_M121(self, gcmd):
-		gcmd._params = {'NAME': 'DWC_BOTTON', 'MOVE': 0}
-		self.gcode.cmd_RESTORE_GCODE_STATE(gcmd)
+		gcmd = self.parse_params('RESTORE_GCODE_STATE NAME=DWC MOVE=0')
+		handler = self.gcode.gcode_handlers.get("RESTORE_GCODE_STATE", self.gcode.cmd_default)
+		handler(gcmd)
 	#	set heatbed, now handled when not defined in cmd_default
 	#	setting babysteps:
 	def cmd_M290(self, gcmd):

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -98,7 +98,7 @@ class web_dwc2:
 
 		# override default instance method by one that calls dwc2 response callback
 		self.gcode.respond_raw = self.respond_raw
-		self.respond_callbacks = [self.gcode_response)] #	if thers a gcode reply, phone me -> see fheilmans its missing in master
+		self.respond_callbacks = [self.gcode_response] #	if thers a gcode reply, phone me -> see fheilmans its missing in master
 
 		#	hopeflly noone get more than 4 extruders up :D
 		self.extruders = [ self.printer.lookup_object('extruder', None) ]

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1073,11 +1073,10 @@ class web_dwc2:
 	#	rrf M32 - start print from sdcard
 	def cmd_M32(self, gcmd):
 		orig = gcmd.get_commandline()
-		filename = orig[orig.find("M23") + 4:].split()[0].strip()
+		filename = orig.split()[1]
 		gcodesfilename = 'gcodes/{}'.format(filename)
 		full_path = "/".join([self.sdpath, gcodesfilename])
 		if os.path.exists(full_path):
-   			self.set_message(full_path)
 			self.sdcard.cmd_M23(self.parse_params("M23 {}".format(gcodesfilename)))
 		else:
 			self.sdcard.cmd_M23(gcmd)
@@ -1198,7 +1197,6 @@ class web_dwc2:
 		while self.gcode_queue:
 			gcmd = self.gcode_queue.pop(0)
 			command = gcmd.get_command()
-			
 			if command in ack_needers or command in self.klipper_macros:
 				gcmd._need_ack = True
 			try:

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -512,7 +512,7 @@ class web_dwc2:
 			gcode_line = self.parse_params(gcodes.pop(0))
 			params = gcode_line.get_command_parameters()
 			#	defaulting to original
-			command = line.get_command()
+			command = gcode_line.get_command()
 
 			#	handle toolchanges
 			if re.match('^T(-)?\d$', command):

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -78,9 +78,7 @@ class web_dwc2:
 		self.file_infos = {}			#	just read files once
 		self.dwc2()
 		logging.basicConfig(level=logging.DEBUG)
-	
-	class CommandError(Exception):
-    	pass
+		
 	# function to replace get_float
 	def get_float(self,key,params,minval=None,maxval=None):
 		if key in params:

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -82,7 +82,7 @@ class web_dwc2:
 	class CommandError(Exception):
     	pass
 	# function to replace get_float
-	def get_float(self, params,key,minval=None,maxval=None):
+	def get_float(self,key,params,minval=None,maxval=None):
 		if key in params:
 			val = params['key']
 			if str.isnumeric(val):

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1135,7 +1135,8 @@ class web_dwc2:
 
 		mm_step = gcmd.get_float('Z', None)
 		if not mm_step: mm_step = gcmd.get_float('S', None)	#	DWC 1 workarround
-		gcmd2 = self.parse_params('SET_GCODE_OFFSET Z_ADJUST=' + str(mm_step) + ' MOVE=1')
+                self.set_message(mm_step)
+		gcmd2 = self.parse_params('SET_GCODE_OFFSET Z_ADJUST' + str(mm_step) + ' MOVE1')
 		self.gcode.cmd_SET_GCODE_OFFSET(gcmd2)
 		self.gcode_reply.append('Z adjusted by %0.2f' % mm_step)
 

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1075,8 +1075,10 @@ class web_dwc2:
 		orig = gcmd.get_commandline()
 		filename = orig[orig.find("M23") + 4:].split()[0].strip()
 		gcodesfilename = 'gcodes/{}'.format(filename)
-		if os.path.exists("/".join([self.sdpath, gcodesfilename])):
-			self.sdcard.cmd_M23(self.parse_params("M23 \"{}\"".format(gcodesfilename)))
+		full_path = "/".join([self.sdpath, gcodesfilename])
+		if os.path.exists(full_path):
+   			self.set_message(full_path)
+			self.sdcard.cmd_M23(self.parse_params("M23 {}".format(gcodesfilename)))
 		else:
 			self.sdcard.cmd_M23(gcmd)
 		self.file_infos['running_file'] = self.rr_fileinfo('knackwurst').result()

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1117,7 +1117,7 @@ class web_dwc2:
 
 		mm_step = gcmd.get_float('Z', None)
 		if not mm_step: mm_step = gcmd.get_float('S', None)	#	DWC 1 workarround
-		gcmd2 = self.parse_params('SET_GCODE_OFFSET Z_ADJUST=' + str(mm_step) + ' MOVE1')
+		gcmd2 = self.parse_params('SET_GCODE_OFFSET Z_ADJUST=' + str(mm_step) + ' MOVE=1')
 		self.gcode.cmd_SET_GCODE_OFFSET(gcmd2)
 		self.gcode_reply.append('Z adjusted by %0.2f' % mm_step)
 

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1219,7 +1219,7 @@ class web_dwc2:
 	
 	#	parses gcode commands into params - lifted from gcode._process_commands
 	args_r = re.compile('([A-Z_]+|[A-Z*/])')
-	def parse_params(self, line, need_ack=True):
+	def parse_params(self, line, need_ack=False):
 		line = line.strip()
 		cpos = line.find(';')
 		if cpos >= 0:

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1002,6 +1002,9 @@ class web_dwc2:
 
 	#	rrf G10 command - set heaterstemp
 	def cmd_G10(self, gcmd):
+		params = gcmd.get_command_parameters()
+		params['T'] = params['P']
+		del params['P']
 		handler = self.gcode.gcode_handlers.get("M104", None)
 		return handler
 	#	rrf M0 - cancel print from sd

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -79,8 +79,10 @@ class web_dwc2:
 		self.dwc2()
 		logging.basicConfig(level=logging.DEBUG)
 	
+	class CommandError(Exception):
+    	pass
 	# function to replace get_float
-	def get_float(params,key,minval=0.,maxval=0.):
+	def get_float(self, params,key,minval=0.,maxval=0.):
 		if key in params:
 			val = params['key']
 			if str.isnumeric(val):

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1005,14 +1005,14 @@ class web_dwc2:
 		return ret_
 	
 	def respond_raw(self, msg):
-        if self.gcode.is_fileinput:
-            return
-        try:
-            os.write(self.gcode.fd, msg+"\n")
-            for callback in self.respond_callbacks:
-                callback(msg+"\n")
-        except os.error:
-            logging.exception("Write g-code response")
+		if self.gcode.is_fileinput:
+			return
+		try:
+			os.write(self.gcode.fd, msg+"\n")
+			for callback in self.respond_callbacks:
+				callback(msg+"\n")
+		except os.error:
+			logging.exception("Write g-code response")
 	
 	def get_file_list(self):
 		dname = self.sdcard.sdcard_dirname

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -1116,8 +1116,8 @@ class web_dwc2:
 			return None
 
 		mm_step = gcmd.get_float('Z', None)
-		if not mm_step: mm_step = self.get_float('S', None)	#	DWC 1 workarround
-		gcmd2 = self.parse_params('SET_GCODE_OFFSET Z_ADJUST' + str(mm_step) + ' MOVE1')
+		if not mm_step: mm_step = gcmd.get_float('S', None)	#	DWC 1 workarround
+		gcmd2 = self.parse_params('SET_GCODE_OFFSET Z_ADJUST=' + str(mm_step) + ' MOVE1')
 		self.gcode.cmd_SET_GCODE_OFFSET(gcmd2)
 		self.gcode_reply.append('Z adjusted by %0.2f' % mm_step)
 

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -82,7 +82,7 @@ class web_dwc2:
 	class CommandError(Exception):
     	pass
 	# function to replace get_float
-	def get_float(self, params,key,minval=0.,maxval=0.):
+	def get_float(self, params,key,minval=None,maxval=None):
 		if key in params:
 			val = params['key']
 			if str.isnumeric(val):

--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -78,11 +78,11 @@ class web_dwc2:
 		self.file_infos = {}			#	just read files once
 		self.dwc2()
 		logging.basicConfig(level=logging.DEBUG)
-		
+
 	# function to replace get_float
 	def get_float(self,key,params,minval=None,maxval=None):
 		if key in params:
-			val = params['key']
+			val = params[key]
 			if str.isnumeric(val):
 				val = float(val)
 				if val < minval:


### PR DESCRIPTION
List of Changes:
- fixes #73 by renaming try_load_module to load_object.
- refactors the gcode command definitions to be compatible with the new klippy/gcode.py GCodeCommand handling format
- Moves the hook to the custom gcode from `rr_gcode` to `gcode_reactor_callback`, to simplify handling logic.
- Refactors the SDcard custom gcode logic to tie in better with the existing virtual_sdcard functionality in klipper, this includes overriding the `sdcard.get_file_list` command to list the nested ./gcode/* files that dwc2 uses. 
- Removes the need to modify gcode.py for the response callbacks by overriding the default instance method with one that calls `gcode_response` - this should simplify installation

It seems to be working well with my printer, but it wouldn't hurt to do some additional testing.
