### PR TITLE
Renames try_load_module to load_object because api change

### DIFF
--- a/web_dwc2.py
+++ b/web_dwc2.py
@@ -46,7 +46,7 @@ class web_dwc2:
 		self.reactor = self.printer.get_reactor()
 		self.gcode = self.printer.lookup_object('gcode')
 		self.configfile = self.printer.lookup_object('configfile').read_main_config()
-		self.stepper_enable = self.printer.try_load_module(config, "stepper_enable")
+		self.stepper_enable = self.printer.load_object(config, "stepper_enable")
 		#	gcode execution needs
 		self.gcode_queue = []	#	containing gcode user pushes from dwc2
 		self.gcode_reply = []	#	contains the klippy replys


### PR DESCRIPTION
Fixes API break in printer.try_load_module

https://github.com/KevinOConnor/klipper/commit/787ed452c2abe3bad81ffaf732b0b2609e3534bb

now webserver intializes again.

![IMAGE 2020-05-16 14:34:47](https://user-images.githubusercontent.com/1587480/82119900-71434c80-9782-11ea-9103-b777293646d2.jpg)

Fixes https://github.com/Stephan3/dwc2-for-klipper/issues/73